### PR TITLE
Update docs Python 3.10->3.11, actions versions, Taskipy -> Poe, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,33 @@ Then go to http://localhost:8000
 ## Deploying
 
 To deploy updates, simply push to the `site` branch - the deployment will automatically be handled by Netlify.
+
+## Updating
+
+There are various dependencies in the code and documentation that should be periodically updated to ensure that the workshop is up to date and recommending latest best practices. Here's a list of things to keep an eye on:
+
+### Python version
+
+The code is currently using Python 3.11 because that's the latest that PyTorch officially recommends, although they seem to be deploying packages for 3.12. As new Python versions are released, we should update the code to use the latest stable version supported by PyTorch.
+
+Updating
+
+### Poetry dependencies
+
+It's a good idea to periodically update the Poetry dependencies to the latest version. The easiest way to do this is to run through all the dependencies listed in the main deps sectino and the dev group and to run `poetry install dep1@latest dep2@latest` etc. to update them all. You need to do this once for the main group of deps and once for the dev group via `poetry install --group dev devdep1@latest devdep2@latest`.
+
+There's also the PyTorch dependencies. Poetry has a thing where if you add a custom package index, Poetry needs to download all packages from the index to determine the relevant versions. This means that adding the custom PyTorch package index will cause the package scan to take ~30 minutes or so.
+
+Instead, we manually add the direct link to the wheels in the pyproject.toml. The filenames here need manually updating when the Python version changes, i.e. updating Python v3.10 to v3.11 would mean changing `https://download.pytorch.org/whl/cpu/torch-2.4.0%2Bcpu-cp310-cp310-linux_x86_64.whl` to `https://download.pytorch.org/whl/cpu/torch-2.4.0%2Bcpu-cp311-cp311-linux_x86_64.whl`. (The `cp310` means "CPython 3.10".) This needs to be done manually for each platform.
+
+### GitHub Actions
+
+There are a few actions that are used in the docs that should be periodically checked for updates. These are:
+
+- [`actions/checkout`](https://github.com/actions/checkout){target=_blank} (currently **@v4**)
+- [`actions/setup-python`](https://github.com/actions/setup-python){target=_blank} (currently **@v5**)
+- [`docker/login-action`](https://github.com/docker/login-action){target=_blank} (currently **@v3**)
+- [`docker/metadata-action`](https://github.com/docker/metadata-action){target=_blank} (currently **@v5**)
+- [`docker/build-push-action`](https://github.com/docker/build-push-action){target=_blank} (currently **@v6**)
+
+Most of these actions seem to be stable in terms of the parameters and whatnot and the major version updates indicate a bump in the Nodejs runtime that is being used, but it's best to scan through the documentation / releases to check that there are no breaking changes for us.

--- a/docs/0-setup.md
+++ b/docs/0-setup.md
@@ -4,7 +4,7 @@ title: 0. Setup
 
 # 0. :desktop: Setup
 
-Throughout this tutorial we will be using [GitHub Codespaces](https://github.com/features/codespaces){target="_blank" rel="noopener noreferrer"} to develop our code. This is basically VS Code in a browser - it's pretty cool!
+Throughout this tutorial we will be using [GitHub Codespaces](https://github.com/features/codespaces){target=_blank} to develop our code. This is basically VS Code in a browser - it's pretty cool!
 
 ![screenshot of a GitHub Codespace](images/0-setup/codespaces.webp)
 

--- a/docs/1-creating-rest-api.md
+++ b/docs/1-creating-rest-api.md
@@ -12,10 +12,10 @@ We're starting from an existing model here, so what exactly is it?
 
 You can view the model card on Hugging Face here: https://huggingface.co/distilgpt2
 
-In short, it's an NLP (Natural Language Processing) model that is a distilled (i.e. smaller) version of OpenAI's [GPT-2 model](https://openai.com/blog/gpt-2-1-5b-release/){target="_blank" rel="noopener noreferrer"}. We're using it as a fun and interactive model to use as a starting point for our exercises - it could be any model really, but this one is quite fun to play around with.
+In short, it's an NLP (Natural Language Processing) model that is a distilled (i.e. smaller) version of OpenAI's [GPT-2 model](https://openai.com/blog/gpt-2-1-5b-release/){target=_blank}. We're using it as a fun and interactive model to use as a starting point for our exercises - it could be any model really, but this one is quite fun to play around with.
 
 !!! info "What's the difference between GPT-2 and ChatGPT?"
-    [ChatGPT](https://openai.com/blog/chatgpt/){target="_blank" rel="noopener noreferrer"} is part of the same research efforts by OpenAI, but it uses a fine-tuned version of the [GPT-4o class of models](https://platform.openai.com/docs/models). The newer GPT models and ChatGPT, unlike GPT-2, are closed source which means we can't download them and use them ourselves - we have to use OpenAI's own API to access them.
+    [ChatGPT](https://openai.com/blog/chatgpt/){target=_blank} is part of the same research efforts by OpenAI, but it uses a fine-tuned version of the [GPT-4o class of models](https://platform.openai.com/docs/models). The newer GPT models and ChatGPT, unlike GPT-2, are closed source which means we can't download them and use them ourselves - we have to use OpenAI's own API to access them.
 
     The GPT-3 and GPT-4 models use colossally more parameters than GPT-2 which uses more than our distilled GPT-2 (GPT-3 has 175 billion parameters, GPT-2 has 1.5 billion and our distilled GPT-2 has 82 million), which is how they're able to give answers that are much more sophisticated. GPT-2 is still great for playing around with though - our model is only 350 MB while GPT-3 clocks in at an impressive 800 GB!
 
@@ -33,13 +33,13 @@ In short, it's an NLP (Natural Language Processing) model that is a distilled (i
 
 Most (but not all) ML models use Python, so that's what we're going to use.
 
-There are a bunch of different frameworks and libraries for creating APIs in Python - you might have used / heard of [Flask](https://flask.palletsprojects.com/en/2.2.x/){target="_blank" rel="noopener noreferrer"} and [Django](https://www.djangoproject.com/){target="_blank" rel="noopener noreferrer"} as the main ones. We are instead using a much newer and more modern framework called [FastAPI](https://fastapi.tiangolo.com/){target="_blank" rel="noopener noreferrer"}.
+There are a bunch of different frameworks and libraries for creating APIs in Python - you might have used / heard of [Flask](https://flask.palletsprojects.com/en/2.2.x/){target=_blank} and [Django](https://www.djangoproject.com/){target=_blank} as the main ones. We are instead using a much newer and more modern framework called [FastAPI](https://fastapi.tiangolo.com/){target=_blank}.
 
 You should already be familiar with this from the introductory talk - to summarise, here are the main selling points of FastAPI:
 
 - As the name suggests, it's super simple and quick to get set up and running - there's minimal boilerplate code and the documentation is excellent.
 - It is based on modern language features like type hints, meaning excellent editor support (i.e. completion everywhere) and less code to write.
-- It automatically creates and serves [interactive documentation](https://github.com/Redocly/redoc){target="_blank" rel="noopener noreferrer"} and an [API specification](https://github.com/OAI/OpenAPI-Specification){target="_blank" rel="noopener noreferrer"} for you.
+- It automatically creates and serves [interactive documentation](https://github.com/Redocly/redoc){target=_blank} and an [API specification](https://github.com/OAI/OpenAPI-Specification){target=_blank} for you.
 
 We're really only scratching the surface of what you can do with FastAPI here.
 
@@ -57,7 +57,7 @@ By convention, the code containing all the FastAPI endpoints is put in a file ca
 
 First, we create our FastAPI app instance and create an endpoint on the root of our API. We'll use this endpoint as a simple "health" check - commonly used for orchestration and cloud platforms to verify that your service is running as expected:
 
-!!! example "`src/distilgpt2_api/api.py`"
+!!! example "src/distilgpt2_api/api.py"
     ```python linenums="1"
     from fastapi import FastAPI
 
@@ -72,7 +72,7 @@ First, we create our FastAPI app instance and create an endpoint on the root of 
 Just with this, we've got a working API alongside automatically generated OpenAPI specification and documentation!
 
 !!! tip "What's that `async` doing there?"
-    You might notice that our endpoint has `async` at the front. You may or may not be familiar with the asynchronous programming in general or in Python and the async-await syntax introduced in [Python 3.7](https://docs.python.org/3.7/whatsnew/3.7.html){target="_blank" rel="noopener noreferrer"}.
+    You might notice that our endpoint has `async` at the front. You may or may not be familiar with the asynchronous programming in general or in Python and the async-await syntax introduced in [Python 3.7](https://docs.python.org/3.7/whatsnew/3.7.html){target=_blank}.
 
     All FastAPI endpoints are asynchronous, meaning that you can do await asynchronous functions inside the endpoint - this allows for significant efficiencies when doing things that are dependent on I/O or network calls. For instance, your endpoint can await a call to another network service or a await a call to read a large file. While the app is waiting for the network call / I/O to finish, it is free to do other things like handle other requests. The thread will be woken back up again once the async I/O or network call has finished and the endpoint will resume from where it left off.
 
@@ -101,7 +101,7 @@ Once that's done, we can run our API:
 uvicorn distilgpt2_api.api:app --reload
 ```
 
-This will use the [Uvicorn](https://www.uvicorn.org/){target="_blank" rel="noopener noreferrer"} ASGI server to run our FastAPI application on port 8000 and will automatically reload whenever we make any changes to the code. This means we can keep that running in the background and not worry about having to restart or recompile any code. Pretty neat! ✨
+This will use the [Uvicorn](https://www.uvicorn.org/){target=_blank} ASGI server to run our FastAPI application on port 8000 and will automatically reload whenever we make any changes to the code. This means we can keep that running in the background and not worry about having to restart or recompile any code. Pretty neat! ✨
 
 !!! info "What's this 'ASGI' all about then?"
     Traditionally, web servers serving up Python applications would use the Web Server Gateway Interface (WSGI, pronounced phonetically). This is a standard allowing web servers to call Python code synchronously.
@@ -159,7 +159,7 @@ On a more abstract semantic level, you can this of this endpoint as either *gett
 
 Here's what our new endpoint should look like:
 
-!!! example "`src/distilgpt2_api/api.py`"
+!!! example "src/distilgpt2_api/api.py"
     ```python linenums linenums="1" hl_lines="3 13-23"
     from fastapi import FastAPI
 
@@ -207,9 +207,9 @@ Now, this endpoint is fully working, but there's a problem.
 
 We're re-creating the `TextGenerator` instance every time anyone makes a request to the API, but if we look at the `src/distilgpt2_api/text_generation.py` file, we can see that this is loading the whole DistilGPT2 model in fresh each time. Now, pytorch does cache the model locally so that it doesn't have to download 350 MB each time, but it still takes a while to load the model into memory. We can fix this!
 
-We're going to create a new function, aptly called `get_model`. This model is going to going to be very simple - all it does is instantiate the `TextGenerator` class. The important thing is that we're going to decorate it with the [`functools.cache` decorator](https://docs.python.org/3/library/functools.html#functools.cache){target="_blank" rel="noopener noreferrer"} - this caches the result of the function invocation so that when we run `get_model()` again, we don't actually re-instantiate the `TextGenerator` class - we return the already created instance. Here's what that looks like:
+We're going to create a new function, aptly called `get_model`. This model is going to going to be very simple - all it does is instantiate the `TextGenerator` class. The important thing is that we're going to decorate it with the [`functools.cache` decorator](https://docs.python.org/3/library/functools.html#functools.cache){target=_blank} - this caches the result of the function invocation so that when we run `get_model()` again, we don't actually re-instantiate the `TextGenerator` class - we return the already created instance. Here's what that looks like:
 
-!!! example "`src/distilgpt2_api/api.py`"
+!!! example "src/distilgpt2_api/api.py"
     ```python linenums="1" hl_lines="2 11-14 28"
     import logging
     from functools import cache
@@ -249,11 +249,14 @@ As simple as that, we've reduce the time it takes to run a single text generatio
 
 In fact, we can improve it even further. For every subsequent request to the API, we're going to use the existing loaded model. That's great, but that first request will still take much longer because it has to load the model in fresh. This is confusing for an end-user where the request sometimes takes ages and sometimes is really quick. We can fix this too!
 
-All we need to do is take advantage of some of FastAPI's built-in application lifecycle events, namely the "startup" event. Here's what that looks like:
+All we need to do is take advantage of some of FastAPI's built-in [application lifespan](https://fastapi.tiangolo.com/advanced/events/#lifespan){target=_blank} which takes advantage of the built-in [`asynccontextmanager`](https://docs.python.org/3/library/contextlib.html#contextlib.asynccontextmanager){target=_blank} from `contextlib` which turns a generator function (i.e. a function with a `yield` in) into an asynchronous context manager which implements `__aenter__` and `__aexit__`. Don't worry too much about what this means if you're not familiar with generators and context managers – the important thing is that anything before the `yield` happens at startup and anything afterwards happens at shutdown.
 
-!!! example "`src/distilgpt2_api/api.py`"
-    ```python linenums="1" hl_lines="17-19"
+Here's what that looks like:
+
+!!! example "src/distilgpt2_api/api.py"
+    ```python linenums="1" hl_lines="2 18-23"
     import logging
+    from contextlib import asynccontextmanager
     from functools import cache
 
     from fastapi import FastAPI
@@ -269,9 +272,12 @@ All we need to do is take advantage of some of FastAPI's built-in application li
         return TextGenerator()
 
 
-    @app.on_event("startup")
-    async def on_startup():
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI):
+        # This happens when the server starts up - any initialisation can go here.
         get_model()
+        yield
+        # This happens when the server shuts down - any cleanup can go here.
 
 
     @app.get("/")

--- a/docs/1-creating-rest-api.md
+++ b/docs/1-creating-rest-api.md
@@ -210,7 +210,7 @@ We're re-creating the `TextGenerator` instance every time anyone makes a request
 We're going to create a new function, aptly called `get_model`. This model is going to going to be very simple - all it does is instantiate the `TextGenerator` class. The important thing is that we're going to decorate it with the [`functools.cache` decorator](https://docs.python.org/3/library/functools.html#functools.cache){target=_blank} - this caches the result of the function invocation so that when we run `get_model()` again, we don't actually re-instantiate the `TextGenerator` class - we return the already created instance. Here's what that looks like:
 
 !!! example "src/distilgpt2_api/api.py"
-    ```python linenums="1" hl_lines="2 11-14 28"
+    ```python linenums="1" hl_lines="1-2 9-12 29"
     import logging
     from functools import cache
 
@@ -218,13 +218,14 @@ We're going to create a new function, aptly called `get_model`. This model is go
 
     from .text_generation import TextGenerator
 
-    app = FastAPI()
-
 
     @cache
     def get_model() -> TextGenerator:
         logging.info("Loading DistilGPT2 model")
         return TextGenerator()
+
+
+    app = FastAPI()
 
 
     @app.get("/")
@@ -254,7 +255,7 @@ All we need to do is take advantage of some of FastAPI's built-in [application l
 Here's what that looks like:
 
 !!! example "src/distilgpt2_api/api.py"
-    ```python linenums="1" hl_lines="2 18-23"
+    ```python linenums="1" hl_lines="2 16-21 24"
     import logging
     from contextlib import asynccontextmanager
     from functools import cache
@@ -262,8 +263,6 @@ Here's what that looks like:
     from fastapi import FastAPI
 
     from .text_generation import TextGenerator
-
-    app = FastAPI()
 
 
     @cache
@@ -278,6 +277,9 @@ Here's what that looks like:
         get_model()
         yield
         # This happens when the server shuts down - any cleanup can go here.
+
+
+    app = FastAPI(lifespan=lifespan)
 
 
     @app.get("/")

--- a/docs/2-containerising-it.md
+++ b/docs/2-containerising-it.md
@@ -25,11 +25,11 @@ First of all, let's reiterate a bit of terminology:
 
 **Container** - a running instance of a container image. You can run as many container instances as you want from a single image, and once the container is running you can access a shell in that container and run whatever commands you want like any other command line[^1]. This can be super useful for debugging any problems!
 
-[^1]: This assumes that the image you're working with has a shell installed - if you have an image using the [scratch](https://hub.docker.com/_/scratch){target="_blank" rel="noopener noreferrer"} image, you won't have *anything* like this. It's precisely for this reason that using this image isn't recommended unless you specifically need *very very* small Docker images.
+[^1]: This assumes that the image you're working with has a shell installed - if you have an image using the [scratch](https://hub.docker.com/_/scratch){target=_blank} image, you won't have *anything* like this. It's precisely for this reason that using this image isn't recommended unless you specifically need *very very* small Docker images.
 
 **Container engine** - The software that handles all the container-related tasks like building images, running containers, killing containers, etc.
 
-**Container registry** - This is a server that acts as a library for storing and retrieving images. There are public ones like [Docker Hub](https://hub.docker.com/){target="_blank" rel="noopener noreferrer"} and [Singularity Hub](https://singularityhub.com/){target="_blank" rel="noopener noreferrer"}. We're using GitHub's container registry, also called [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry){target="_blank" rel="noopener noreferrer"} or GHCR for short.
+**Container registry** - This is a server that acts as a library for storing and retrieving images. There are public ones like [Docker Hub](https://hub.docker.com/){target=_blank} and [Singularity Hub](https://singularityhub.com/){target=_blank}. We're using GitHub's container registry, also called [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry){target=_blank} or GHCR for short.
 
 **Tag** - This is a label that you apply to an image. This is usually a version but it can be anything you want! There's one special tag, though: `latest`. This is the default tag that's used if you don't specify a tag and should point to the latest, greatest version of your image. If you're looking for most up-to-date version of any other application's image, you can always look for that `latest` tag.
 
@@ -45,14 +45,14 @@ In fact, containers are really a collection of features of the Linux kernel that
 
 There's no way that another container or process outside of the container runtime can access anything inside your image because the kernel enforces the isolation. This is a really simple concept (the specifics of the implementation are not so simple) but the power and versatility that you can get out of this simple idea are pretty extraordinary!
 
-As all the running containers on your machine share the same kernel, there's much less runtime overhead for containers vs. virtual machines and the container images themselves can be just a few kilobytes instead of gigabytes. (As a rule of thumb, there's not generally any significant CPU overhead for running inside a container, but there is some overhead associated with the network stack. You can read some numbers for container performance characterisation [here](https://www.nginx.com/blog/comparing-nginx-performance-bare-metal-and-virtual-environments/){target="_blank" rel="noopener noreferrer"}.)
+As all the running containers on your machine share the same kernel, there's much less runtime overhead for containers vs. virtual machines and the container images themselves can be just a few kilobytes instead of gigabytes. (As a rule of thumb, there's not generally any significant CPU overhead for running inside a container, but there is some overhead associated with the network stack. You can read some numbers for container performance characterisation [here](https://www.nginx.com/blog/comparing-nginx-performance-bare-metal-and-virtual-environments/){target=_blank}.)
 
 ![Virtual machines vs. containers](images/2-containerising-it/vm-vs-container.png)
 
 **From:** https://blog.netapp.com/blogs/containers-vs-vms/
 {: style="font-size: small; margin-top: -30px; width: 100%; text-align: center;"}
 
-If you want to get a deeper understanding of how containers work under the hood, I'd highly recommend the [blog posts](https://jvns.ca/categories/containers/){target="_blank" rel="noopener noreferrer"} and [zines](https://wizardzines.com/zines/containers/){target="_blank" rel="noopener noreferrer"} by [Julia Evans](https://twitter.com/b0rk){target="_blank" rel="noopener noreferrer"}.
+If you want to get a deeper understanding of how containers work under the hood, I'd highly recommend the [blog posts](https://jvns.ca/categories/containers/){target=_blank} and [zines](https://wizardzines.com/zines/containers/){target=_blank} by [Julia Evans](https://twitter.com/b0rk){target=_blank}.
 
 ### Container technologies
 
@@ -64,11 +64,11 @@ As far as container tooling goes, there's a whale that dominates the market, but
 
 This is the main player in the container world, by far - the metaphorical whale. (It's also the one with the whale logo.) Docker was the company that popularised containerisation, which means the formats created by Docker had a massive impact on the container landscape.
 
-While Docker Inc. is a private company, all of the code behind it is [Open Source](https://github.com/docker/){target="_blank" rel="noopener noreferrer"}. They also spun out their [core container runtime](https://containerd.io/){target="_blank" rel="noopener noreferrer"} functionality into a separate component and donated it to the care of the [Cloud Native Computing Foundation (ONCF)](https://www.cncf.io/){target="_blank" rel="noopener noreferrer"}, a part of the non-profit [Linux Foundation](https://www.linuxfoundation.org/){target="_blank" rel="noopener noreferrer"}.
+While Docker Inc. is a private company, all of the code behind it is [Open Source](https://github.com/docker/){target=_blank}. They also spun out their [core container runtime](https://containerd.io/){target=_blank} functionality into a separate component and donated it to the care of the [Cloud Native Computing Foundation (ONCF)](https://www.cncf.io/){target=_blank}, a part of the non-profit [Linux Foundation](https://www.linuxfoundation.org/){target=_blank}.
 
-In June 2015, Docker and other container companies established the [Open Container Initiative](https://www.opencontainers.org/){target="_blank" rel="noopener noreferrer"} - this organisation is also a Linux Foundation project and designs the specifications for the container runtime - [runtime-spec](https://github.com/opencontainers/runtime-spec){target="_blank" rel="noopener noreferrer"} and image format - [image-spec](https://github.com/opencontainers/image-spec){target="_blank" rel="noopener noreferrer"}.
+In June 2015, Docker and other container companies established the [Open Container Initiative](https://www.opencontainers.org/){target=_blank} - this organisation is also a Linux Foundation project and designs the specifications for the container runtime - [runtime-spec](https://github.com/opencontainers/runtime-spec){target=_blank} and image format - [image-spec](https://github.com/opencontainers/image-spec){target=_blank}.
 
-While Docker is still the main tool, as most of the underlying technologies ([containerd](https://github.com/containerd/containerd){target="_blank" rel="noopener noreferrer"}, [runc](https://github.com/opencontainers/runc){target="_blank" rel="noopener noreferrer"}) and specifications ([OCI Image Spec](https://github.com/opencontainers/image-spec){target="_blank" rel="noopener noreferrer"}, [OCI Runtime Spec](https://github.com/opencontainers/runtime-spec){target="_blank" rel="noopener noreferrer"}) are open source, there are plenty of alternative tools that you can use.
+While Docker is still the main tool, as most of the underlying technologies ([containerd](https://github.com/containerd/containerd){target=_blank}, [runc](https://github.com/opencontainers/runc){target=_blank}) and specifications ([OCI Image Spec](https://github.com/opencontainers/image-spec){target=_blank}, [OCI Runtime Spec](https://github.com/opencontainers/runtime-spec){target=_blank}) are open source, there are plenty of alternative tools that you can use.
 
 #### Podman
 
@@ -76,12 +76,12 @@ While Docker is still the main tool, as most of the underlying technologies ([co
 
 Even though it dominates the market, Docker isn't the only container runtime around with a logo of a happy cute sea animal!
 
-Enter [Podman](https://podman.io/){target="_blank" rel="noopener noreferrer"}.
+Enter [Podman](https://podman.io/){target=_blank}.
 
 The main differentiator between Docker and Podman is that Podman doesn't need a daemon running in the background (usually as root)[^3]. This makes it popular for security-conscious users or where root access to the underlying machine is not available (e.g. in HPC environments) or where you don't have root permissions on the machine.
 
 [^3]:
-    The Docker daemon *can* now run in [rootless mode](https://docs.docker.com/engine/security/rootless/){target="_blank" rel="noopener noreferrer"}. As of Docker Engine v20.10 this is no longer considered experimental, but even rootless Docker still runs with a daemon - it just runs the daemon inside a user namespace.
+    The Docker daemon *can* now run in [rootless mode](https://docs.docker.com/engine/security/rootless/){target=_blank}. As of Docker Engine v20.10 this is no longer considered experimental, but even rootless Docker still runs with a daemon - it just runs the daemon inside a user namespace.
 
 #### Apptainer / Singularity
 
@@ -107,9 +107,9 @@ The first step to containerising any application is to create a file called `Doc
 
 We're going to start off by specifying a base image - this comes with Python built-in, which means we don't have to worry about installing the right version of Python.
 
-!!! example "`Dockerfile`"
+!!! example "Dockerfile"
     ```dockerfile linenums="1"
-    FROM python:3.10-slim
+    FROM python:3.11-slim
 
     COPY . .
 
@@ -124,7 +124,7 @@ We're going to start off by specifying a base image - this comes with Python bui
     ]
     ```
 
-This is pretty much as simple you can can get. It starts off with the official Python 3.10 image (the slim version, meaning it's slightly smaller than the default image).
+This is pretty much as simple you can can get. It starts off with the official Python 3.11 image (the slim version, meaning it's slightly smaller than the default image).
 
 Next, it copies all of our code from our repository into the image.
 
@@ -143,12 +143,12 @@ Now, we can build this image and run it right now if we want to, but we're not g
 
 Next, we're going to update our `Dockerfile` to install Poetry, the tool we're using for managing our Python dependencies.
 
-!!! example "`Dockerfile`"
+!!! example "Dockerfile"
     ```dockerfile linenums="1" hl_lines="3-13"
-    FROM python:3.10-slim
+    FROM python:3.11-slim
 
     ENV \
-        POETRY_VERSION="1.3.2" \
+        POETRY_VERSION="1.8.3" \
         POETRY_VIRTUALENVS_IN_PROJECT=true \
         POETRY_NO_INTERACTION=1 \
         VENV_PATH="/app/.venv"
@@ -176,12 +176,12 @@ There's quite a lot going on here, but the important bit is really line 13. That
 
 Now that we've got Poetry installed, we're ready to install all of our application dependencies:
 
-!!! example "`Dockerfile`"
+!!! example "Dockerfile"
     ```dockerfile linenums="1" hl_lines="16"
-    FROM python:3.10-slim
+    FROM python:3.11-slim
 
     ENV \
-        POETRY_VERSION="1.3.2" \
+        POETRY_VERSION="1.8.3" \
         POETRY_VIRTUALENVS_IN_PROJECT=true \
         POETRY_NO_INTERACTION=1 \
         VENV_PATH="/app/.venv"
@@ -193,7 +193,7 @@ Now that we've got Poetry installed, we're ready to install all of our applicati
     RUN pip install pipx && pipx install poetry==$POETRY_VERSION
 
     COPY . .
-    RUN poetry install --no-dev
+    RUN poetry install --only main
 
     EXPOSE 8000
 
@@ -243,7 +243,7 @@ cp .gitignore .dockerignore
 
 There's a few extra things you can ignore from Docker that you can't from git - let's add these to the beginning of the `.dockerignore`:
 
-!!! example "`.dockerignore`"
+!!! example ".dockerignore"
     ```bash linenums="1"
     .dockerignore
     .gitignore
@@ -257,12 +257,12 @@ There's a few extra things you can ignore from Docker that you can't from git - 
 
 Next, let's update our Dockerfile so that we add and install all of our dependencies before adding our actual application code. What this means is that if we are only updating our application code but not updating any dependencies, when we re-build our Docker image, we don't need to re-install the dependencies in the build process - Docker will use the build cache that it maintains to speed up the build process massively.
 
-!!! example "`Dockerfile`"
+!!! example "Dockerfile"
     ```dockerfile linenums="1" hl_lines="15-20"
-    FROM python:3.10-slim
+    FROM python:3.11-slim
 
     ENV \
-        POETRY_VERSION="1.3.2" \
+        POETRY_VERSION="1.8.3" \
         POETRY_VIRTUALENVS_IN_PROJECT=true \
         POETRY_NO_INTERACTION=1 \
         VENV_PATH="/app/.venv"
@@ -274,11 +274,11 @@ Next, let's update our Dockerfile so that we add and install all of our dependen
     RUN pip install pipx && pipx install poetry==$POETRY_VERSION
 
     COPY ./pyproject.toml ./poetry.lock ./
-    RUN poetry install --no-dev --no-root
+    RUN poetry install --only main --no-root
 
     COPY README.md ./
     COPY src ./src
-    RUN poetry install --no-dev
+    RUN poetry install --only main
 
     EXPOSE 8000
 

--- a/docs/3-cicd-with-github-actions.md
+++ b/docs/3-cicd-with-github-actions.md
@@ -30,7 +30,7 @@ Our first GitHub Action workflow is going to be a simple "lint" workflow.
 
 GitHub Actions workflows all live in the `.github/workflows` folder. Each workflow has it's own YAML file. Let's create our lint workflow YAML file:
 
-!!! example "`.github/workflows/lint.yml`"
+!!! example ".github/workflows/lint.yml"
     ```yaml linenums="1"
     name: Lint
 
@@ -51,7 +51,7 @@ By specifying `push` and `pull_request` under the `on` section, we're saying tha
 
 Now that we've got the boilerplate, let's add some actual steps. First, we're going to checkout the code into the Action runner:
 
-!!! example "`.github/workflows/lint.yml`"
+!!! example ".github/workflows/lint.yml"
     ```yaml linenums="1" hl_lines="12"
     name: Lint
 
@@ -64,10 +64,10 @@ Now that we've got the boilerplate, let's add some actual steps. First, we're go
       lint:
         runs-on: ubuntu-latest
         steps:
-          - uses: actions/checkout@v3
+          - uses: actions/checkout@v4
     ```
 
-The `uses` here indicates that we're using a pre-built step from another repository. As we specify `actions/checkout` as the repository, we know that we are using the pre-built Action step specified in https://github.com/actions/checkout. The `@v3` means that we are using git tag `v3` of the action.
+The `uses` here indicates that we're using a pre-built step from another repository. As we specify `actions/checkout` as the repository, we know that we are using the pre-built Action step specified in https://github.com/actions/checkout. The `@v4` means that we are using git tag `v4` of the action, the latest major release at the time of writing.
 
 As you might expect, this is an official pre-built Action from GitHub. There are loads of different pre-built Actions you can use, though - some of them official and some of them unofficial.
 
@@ -75,7 +75,7 @@ There's even a marketplace where you can see all the different Actions you can t
 
 Next, let's set up Poetry and Python:
 
-!!! example "`.github/workflows/lint.yml`"
+!!! example ".github/workflows/lint.yml"
     ```yaml linenums="1" hl_lines="14-22"
     name: Lint
 
@@ -88,27 +88,27 @@ Next, let's set up Poetry and Python:
       lint:
         runs-on: ubuntu-latest
         steps:
-          - uses: actions/checkout@v3
+          - uses: actions/checkout@v4
     
           - name: Install Poetry
             run: pipx install poetry
     
           - name: Set up Python
             id: setup-python
-            uses: actions/setup-python@v4
+            uses: actions/setup-python@v5
             with:
-              python-version: '3.10'
+              python-version: '3.11'
               cache: poetry
     ```
 
 The GitHub-hosted runners come with a load of packages pre-installed, so we don't need to worry about installing `pipx` - it's already there! We do want to have a special action for setting up Python, though, because:
 
-- It makes sure we are using the correct version of Python, i.e. 3.10 instead of 3.8 or 3.11.
+- It makes sure we are using the correct version of Python, i.e. 3.11 instead of 3.9 or 3.12.
 - It sets up the caching of dependencies for us to speed up subsequent builds.
 
 Now that we have Poetry and Python set up, we can install our dependencies:
 
-!!! example "`.github/workflows/lint.yml`"
+!!! example ".github/workflows/lint.yml"
     ```yaml linenums="1" hl_lines="24-26"
     name: Lint
 
@@ -121,25 +121,32 @@ Now that we have Poetry and Python set up, we can install our dependencies:
       lint:
         runs-on: ubuntu-latest
         steps:
-          - uses: actions/checkout@v3
+          - uses: actions/checkout@v4
     
           - name: Install Poetry
             run: pipx install poetry
     
           - name: Set up Python
             id: setup-python
-            uses: actions/setup-python@v4
+            uses: actions/setup-python@v5
             with:
-              python-version: '3.10'
+              python-version: '3.11'
               cache: poetry
     
           - name: Install project
             run: poetry install --no-interaction
     ```
 
-It's as simple as that! Finally, we can add our command to lint our code. We've already added a task for this to the `pyproject.toml` configuration using [Taskipy](https://github.com/illBeRoy/taskipy), so we can go ahead and run that now:
+It's as simple as that!
 
-!!! example "`.github/workflows/lint.yml`"
+Finally, we can add our command to lint our code. We've already added a task for this to the `pyproject.toml` configuration using [Poe the Poet](https://poethepoet.natn.io/index.html). You can view all the configured tasks by running `poe --help`.
+
+!!! tip "Check your workflow locally first."
+    It takes a few minutes for the GitHub Actions runner to run your linting task which means the lint fail, fix, re-run loop is quite long. There's a task called `pre-commit` which you can run locally first before pushing using `poe pre-commit` - this will format your code and run the linter so that you can fix any issues before pushing the code up.
+
+Let's add our linting task to the workflow:
+
+!!! example ".github/workflows/lint.yml"
     ```yaml linenums="1" hl_lines="27-28"
     name: Lint
 
@@ -152,23 +159,23 @@ It's as simple as that! Finally, we can add our command to lint our code. We've 
       lint:
         runs-on: ubuntu-latest
         steps:
-          - uses: actions/checkout@v3
+          - uses: actions/checkout@v4
     
           - name: Install Poetry
             run: pipx install poetry
     
           - name: Set up Python
             id: setup-python
-            uses: actions/setup-python@v4
+            uses: actions/setup-python@v5
             with:
-              python-version: '3.10'
+              python-version: '3.11'
               cache: poetry
     
           - name: Install project
             run: poetry install --no-interaction
     
           - name: Lint
-            run: poetry run task lint
+            run: poetry run poe lint
     ```
 
 That's all there is to it!
@@ -179,7 +186,7 @@ Go ahead and commit this and push it up, and take a look at the "Actions" tab in
 
 Now that we have a linting workflow, we're going to add another workflow for testing our code. We've already got our pytest test set up and ready to go, we just need to create our workflow YAML file. We can use 90% of the same code as the linting workflow with a couple of minor tweaks:
 
-!!! example "`.github/workflows/test.yaml`"
+!!! example ".github/workflows/test.yaml"
     ```yaml linenums="1" hl_lines="1 27-28"
     name: Test
 
@@ -192,23 +199,23 @@ Now that we have a linting workflow, we're going to add another workflow for tes
       test:
         runs-on: ubuntu-latest
         steps:
-          - uses: actions/checkout@v3
+          - uses: actions/checkout@v4
     
           - name: Install Poetry
             run: pipx install poetry
 
           - name: Set up Python
             id: setup-python
-            uses: actions/setup-python@v4
+            uses: actions/setup-python@v5
             with:
-              python-version: '3.10'
+              python-version: '3.11'
               cache: poetry
 
           - name: Install project
             run: poetry install --no-interaction
 
           - name: Test
-            run: poetry run task test
+            run: poetry run poe test
     ```
 
 You can see here that there are only 3 lines different from the linting workflow - all the setup is the same.
@@ -219,7 +226,7 @@ Commit this and push it up, and you should see our new "Test" workflow running a
 
 Our final GitHub Actions workflow is going to build the Docker image for our FastAPI application and push it up to the GitHub Container Registry. This will link the pushed image with our repository so that it appears under the "Packages" section, beneath "Releases". We're going to make it publicly available so that our Azure App Service can easily find it later in the next section.
 
-!!! example "`.github/workflows/deploy.yml`"
+!!! example ".github/workflows/deploy.yml"
     ```yaml linenums="1"
     name: Deploy
 
@@ -234,7 +241,7 @@ Our final GitHub Actions workflow is going to build the Docker image for our Fas
         runs-on: ubuntu-latest
         steps:
           - name: Checkout repository
-            uses: actions/checkout@v3
+            uses: actions/checkout@v4
     ```
 
 This is going to start out fairly similar to the lint and test workflows. There are a couple of differences, however:
@@ -244,7 +251,7 @@ This is going to start out fairly similar to the lint and test workflows. There 
 
 The first real step of the Docker build and push process is to log into the GitHub container registry. To do this, we're using a built-in called `secrets.GITHUB_TOKEN`:
 
-!!! example "`.github/workflows/deploy.yml`"
+!!! example ".github/workflows/deploy.yml"
     ```yaml linenums="1" hl_lines="16-21"
     name: Deploy
 
@@ -259,10 +266,10 @@ The first real step of the Docker build and push process is to log into the GitH
         runs-on: ubuntu-latest
         steps:
           - name: Checkout repository
-            uses: actions/checkout@v3
+            uses: actions/checkout@v4
 
           - name: Log in to the Container registry
-            uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+            uses: docker/login-action@v3
             with:
               registry: ${{ env.REGISTRY }}
               username: ${{ github.actor }}
@@ -271,7 +278,7 @@ The first real step of the Docker build and push process is to log into the GitH
 
 Next, we're going to use another pre-built action to generate all the right metadata for our Docker image. This does things like set the correct tag based on the tag and/or branch, set labels to indicate who created the image, what version it is, what the GitHub repository URL is, etc. This also links the image with the repository within the GitHub user interface so that the image is shown on the page for the repository.
 
-!!! example "`.github/workflows/deploy.yml`"
+!!! example ".github/workflows/deploy.yml"
     ```yaml linenums="1" hl_lines="23-30"
     name: Deploy
 
@@ -286,10 +293,10 @@ Next, we're going to use another pre-built action to generate all the right meta
         runs-on: ubuntu-latest
         steps:
           - name: Checkout repository
-            uses: actions/checkout@v3
+            uses: actions/checkout@v4
 
           - name: Log in to the Container registry
-            uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+            uses: docker/login-action@v3
             with:
               registry: ${{ env.REGISTRY }}
               username: ${{ github.actor }}
@@ -297,7 +304,7 @@ Next, we're going to use another pre-built action to generate all the right meta
 
           - name: Extract metadata (tags, labels) for Docker
             id: meta
-            uses: docker/metadata-action@v4.3.0
+            uses: docker/metadata-action@v5
             with:
               images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
               tags: |
@@ -306,8 +313,8 @@ Next, we're going to use another pre-built action to generate all the right meta
 
 With our metadata generated, we can add another step to actually build and push the Docker image. We can use another pre-built Action for this as well:
 
-!!! example "`.github/workflows/deploy.yml`"
-    ```yaml linenums="1" hl_lines="32-38"
+!!! example ".github/workflows/deploy.yml"
+    ```yaml linenums="1" hl_lines="31-38"
     name: Deploy
 
     on: [push]
@@ -321,10 +328,10 @@ With our metadata generated, we can add another step to actually build and push 
         runs-on: ubuntu-latest
         steps:
           - name: Checkout repository
-            uses: actions/checkout@v3
+            uses: actions/checkout@v4
 
           - name: Log in to the Container registry
-            uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+            uses: docker/login-action@v3
             with:
               registry: ${{ env.REGISTRY }}
               username: ${{ github.actor }}
@@ -332,14 +339,14 @@ With our metadata generated, we can add another step to actually build and push 
 
           - name: Extract metadata (tags, labels) for Docker
             id: meta
-            uses: docker/metadata-action@v4.3.0
+            uses: docker/metadata-action@v5
             with:
               images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
               tags: |
                 type=raw,value=latest
 
           - name: Build and push Docker image
-            uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+            uses: docker/build-push-action@v6
             with:
               context: .
               push: true
@@ -358,6 +365,13 @@ Before we push this up, we just need to make a quick modification in the reposit
     GitHub have been making a lot of changes to the workflow token authorisation recently, and a few people have noticed some bugs where the workflow permissions aren't updated even though the setting has been changed. This shouldn't happen to you, but if it does, try renaming the repository to something else - this should fix the problem. Yes, it is weird.
 
 That's it! Commit that and push it up, and you should see your image pushed up to your container registry.
+
+!!! tip "Be careful when caching Docker builds in your CI/CD"
+    It's possible to cache your CI/CD builds in GitHub Actions (or other CI/CD) by doing things like pulling the latest image from the registry and caching your builds from that.
+
+    You need to be careful doing this, because often upstream images will be constantly updated with security patches and minor updates to packages. If you're caching your builds, it's possible to go months without pulling in any of these updates, which can leave outdated and vulnerable software in your images.
+
+    In general, I would recommend doing completely fresh image builds every time in your CI/CD, even if that means it takes another minute or two.
 
 Take a look at your repository now. You should see something new under the "Packages" section, underneath "Releases":
 

--- a/docs/4-deploying-to-azure.md
+++ b/docs/4-deploying-to-azure.md
@@ -6,7 +6,7 @@ title: 4. Deploying to Azure
 
 Now that we've got a working continuous deployment pipeline taking changes to our code and pushing Docker images up into the GitHub Container Registry, we can deploy our application to the cloud as a cloud-native web service.
 
-To do this, we're going to use [Microsoft's Azure](https://azure.microsoft.com/en-gb){target="_blank" rel="noopener noreferrer"} cloud computing service - in particular, a service called [Azure App Service](https://azure.microsoft.com/en-us/products/app-service/){target="_blank" rel="noopener noreferrer"}.
+To do this, we're going to use [Microsoft's Azure](https://azure.microsoft.com/en-gb){target=_blank} cloud computing service - in particular, a service called [Azure App Service](https://azure.microsoft.com/en-us/products/app-service/){target=_blank}.
 
 ## Recap - cloud and Azure
 
@@ -156,7 +156,7 @@ This should show a little JSON object with a key called `CI_CD_URL` - this is th
 
 Let's update our GitHub Action workflow to add this in:
 
-!!! example "`.github/workflows/`"
+!!! example ".github/workflows/"
     ```yaml linenums="1"
     name: Deploy
 
@@ -171,10 +171,10 @@ Let's update our GitHub Action workflow to add this in:
         runs-on: ubuntu-latest
         steps:
           - name: Checkout repository
-            uses: actions/checkout@v3
+            uses: actions/checkout@v4
 
           - name: Log in to the Container registry
-            uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+            uses: docker/login-action@v3
             with:
               registry: ${{ env.REGISTRY }}
               username: ${{ github.actor }}
@@ -182,14 +182,14 @@ Let's update our GitHub Action workflow to add this in:
 
           - name: Extract metadata (tags, labels) for Docker
             id: meta
-            uses: docker/metadata-action@v4.3.0
+            uses: docker/metadata-action@v5
             with:
               images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
               tags: |
                 type=raw,value=latest
 
           - name: Build and push Docker image
-            uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+            uses: docker/build-push-action@v6
             with:
               context: .
               push: true
@@ -238,7 +238,7 @@ Now that we've got it all up and working, let's test it out!
 
 To try it out, let's make a minor change to our root endpoint. This will add the current application version to the health endpoint result:
 
-!!! example "`src/distilgpt2_api/api.py`"
+!!! example "src/distilgpt2_api/api.py"
     ```python linenums="1" hl_lines="3 25"
     import logging
     from functools import cache

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 ## :wave: Welcome
 
-Welcome to the "Introduction to Docker and GitHub Actions for ML apps" workshop, part of the "Fundamentals of Cloud Computing" course within STFC Hartree Centre's [HNCDI Explain programme](https://www.hartree.stfc.ac.uk/digital-innovation/hartree-national-centre-for-digital-innovation/explain/){target="_blank" rel="noopener noreferrer"}.
+Welcome to the "Introduction to Docker and GitHub Actions for ML apps" workshop, part of the "Fundamentals of Cloud Computing" course within STFC Hartree Centre's [HNCDI Explain programme](https://www.hartree.stfc.ac.uk/digital-innovation/hartree-national-centre-for-digital-innovation/explain/){target=_blank}.
 
 In this workshop, we will be trying out the stuff we discussed in our introductory presentation by:
 


### PR DESCRIPTION
- remove the rel=noopener referrer which isn't a thing anymore.
- remove the code formatting from example block titles, it just looks silly.
- udpate FastAPI lifecycle event `@app.on_startup()` to app lifespan `lifespan(app: FastAPI)` as the startup event is now deprecated.